### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/newportApp/src/drvESP300.cc
+++ b/newportApp/src/drvESP300.cc
@@ -97,7 +97,7 @@ int ESP300_num_cards = 0;
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -225,7 +225,7 @@ static int set_status(int card, int signal)
     status.All = motor_info->status.All;
 
     sprintf(outbuff, "%.2dMD", signal + 1);
-    send_mess(card, outbuff, (char*) NULL);
+    send_mess(card, outbuff, NULL);
     charcnt = recv_mess(card, inbuff, 1);
 
     if (charcnt == 1 && (inbuff[0] == '0' || inbuff[0] == '1'))
@@ -255,7 +255,7 @@ static int set_status(int card, int signal)
 
     /* Get motor position. */
     sprintf(outbuff, READ_POSITION, signal + 1);
-    send_mess(card, outbuff, (char*) NULL);
+    send_mess(card, outbuff, NULL);
     charcnt = recv_mess(card, inbuff, 1);
 
     motorData = atof(inbuff) / cntrl->drive_resolution[signal];
@@ -279,7 +279,7 @@ static int set_status(int card, int signal)
 
     /* Get travel limit switch status. */
     sprintf(outbuff, "%.2dPH", signal + 1);
-    send_mess(card, outbuff, (char*) NULL);
+    send_mess(card, outbuff, NULL);
     charcnt = recv_mess(card, inbuff, 1);
     cptr = strchr(inbuff, 'H');
     if (cptr == NULL)
@@ -318,7 +318,7 @@ static int set_status(int card, int signal)
 
     /* Get motor power on/off status. */
     sprintf(outbuff, "%.2dMO?", signal + 1);
-    send_mess(card, outbuff, (char*) NULL);
+    send_mess(card, outbuff, NULL);
     charcnt = recv_mess(card, inbuff, 1);
     power = atoi(inbuff) ? true : false;
 
@@ -331,7 +331,7 @@ static int set_status(int card, int signal)
 
     /* Get error code. */
     sprintf(outbuff, "%.2dTE?", signal + 1);
-    send_mess(card, outbuff, (char*) NULL);
+    send_mess(card, outbuff, NULL);
     charcnt = recv_mess(card, inbuff, 1);
     errcode = atoi(inbuff);
     if (errcode != 0)
@@ -358,7 +358,7 @@ static int set_status(int card, int signal)
         nodeptr->postmsgptr != 0)
     {
         strcpy(outbuff, nodeptr->postmsgptr);
-        send_mess(card, outbuff, (char*) NULL);
+        send_mess(card, outbuff, NULL);
         nodeptr->postmsgptr = NULL;
     }
 
@@ -372,7 +372,7 @@ exit:
 /* send a message to the ESP300 board            */
 /* send_mess()                               */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct MMcontroller *cntrl;
     size_t size;
@@ -638,7 +638,7 @@ static int motor_init()
 
             do
             {
-                send_mess(card_index, GET_IDENT, (char*) NULL);
+                send_mess(card_index, GET_IDENT, NULL);
                 status = recv_mess(card_index, buff, 1);
                 retry++;
                 /* Return value is length of response string */
@@ -648,11 +648,11 @@ static int motor_init()
 errexit:
         if (success_rtn == asynSuccess && status > 0)
         {
-            brdptr->localaddr = (char *) NULL;
+            brdptr->localaddr = NULL;
             brdptr->motor_in_motion = 0;
             strcpy(brdptr->ident, &buff[1]);  /* Skip "\n" */
 
-            send_mess(card_index, "ZU", (char*) NULL);
+            send_mess(card_index, "ZU", NULL);
             recv_mess(card_index, buff, 1);
             total_axis = buff[0] >> 4;
             if (total_axis > 4)
@@ -664,7 +664,7 @@ errexit:
             for (motor_index = 0; motor_index < total_axis; motor_index++)
             {
                 sprintf(buff, STOP_AXIS, motor_index + 1);  /* Stop motor */
-                send_mess(card_index, buff, (char*) NULL);
+                send_mess(card_index, buff, NULL);
                 /* Initialize. */
                 brdptr->motor_info[motor_index].motor_motion = NULL;
             }

--- a/newportApp/src/drvMM3000.cc
+++ b/newportApp/src/drvMM3000.cc
@@ -123,7 +123,7 @@ int MM3000_num_cards = 0;
 
 /*----------------functions-----------------*/
 STATIC int recv_mess(int, char *, int);
-STATIC RTN_STATUS send_mess(int, char const *, char *);
+STATIC RTN_STATUS send_mess(int, const char *, const char *);
 STATIC int set_status(int, int);
 static long report(int);
 static long init();
@@ -245,7 +245,7 @@ STATIC int set_status(int card, int signal)
     status.All = motor_info->status.All;
 
     sprintf(outbuff, "%dMS", signal + 1);
-    send_mess(card, outbuff, (char*) NULL);
+    send_mess(card, outbuff, NULL);
     charcnt = recv_mess(card, inbuff, 1);
     if (charcnt > 0)
     {
@@ -310,7 +310,7 @@ STATIC int set_status(int card, int signal)
     status.Bits.EA_HOME     = 0;
 
     sprintf(outbuff, "%dTP", signal + 1);
-    send_mess(card, outbuff, (char*) NULL);
+    send_mess(card, outbuff, NULL);
     charcnt = recv_mess(card, inbuff, 1);
     if (charcnt > 0)
     {
@@ -373,7 +373,7 @@ STATIC int set_status(int card, int signal)
         nodeptr->postmsgptr != 0)
     {
         strcpy(outbuff, nodeptr->postmsgptr);
-        send_mess(card, outbuff, (char*) NULL);
+        send_mess(card, outbuff, NULL);
         nodeptr->postmsgptr = NULL;
     }
 
@@ -387,7 +387,7 @@ exit:
 /* send a message to the MM3000 board            */
 /* send_mess()                               */
 /*****************************************************/
-STATIC RTN_STATUS send_mess(int card, char const *com, char *name)
+STATIC RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct MMcontroller *cntrl;
     size_t size;

--- a/newportApp/src/drvMM4000.cc
+++ b/newportApp/src/drvMM4000.cc
@@ -142,7 +142,7 @@ volatile int drvMM4000ReadbackDelay = 0;
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *name);
+static RTN_STATUS send_mess(int, const char *, const char *name);
 static void start_status(int card);
 static int set_status(int card, int signal);
 static long report(int level);
@@ -259,14 +259,14 @@ static void start_status(int card)
     if (card >= 0)
     {
         cntrl = (struct MMcontroller *) motor_state[card]->DevicePrivate;
-        send_mess(card, READ_STATUS, (char*) NULL);
+        send_mess(card, READ_STATUS, NULL);
         status = recv_mess(card, cntrl->status_string, 1);
         if (status > 0)
         {
             cntrl->status = NORMAL;
-            send_mess(card, READ_POSITION, (char*) NULL);
+            send_mess(card, READ_POSITION, NULL);
             recv_mess(card, cntrl->position_string, 1);
-            send_mess(card, READ_FEEDBACK, (char*) NULL);
+            send_mess(card, READ_FEEDBACK,  NULL);
             recv_mess(card, cntrl->feedback_string, 1);
         }
         else
@@ -284,7 +284,7 @@ static void start_status(int card)
          * responses.  This minimizes the latency due to processing on each card
          */
         for (itera = 0; (itera < total_cards) && motor_state[itera]; itera++)
-            send_mess(itera, READ_STATUS, (char*) NULL);
+            send_mess(itera, READ_STATUS, NULL);
         for (itera = 0; (itera < total_cards) && motor_state[itera]; itera++)
         {
             cntrl = (struct MMcontroller *) motor_state[itera]->DevicePrivate;
@@ -292,7 +292,7 @@ static void start_status(int card)
             if (status > 0)
             {
                 cntrl->status = NORMAL;
-                send_mess(itera, READ_FEEDBACK, (char*) NULL);
+                send_mess(itera, READ_FEEDBACK, NULL);
                 recv_mess(itera, cntrl->feedback_string, 1);
             }
             else
@@ -304,7 +304,7 @@ static void start_status(int card)
             }
         }
         for (itera = 0; (itera < total_cards) && motor_state[itera]; itera++)
-            send_mess(itera, READ_POSITION, (char*) NULL);
+            send_mess(itera, READ_POSITION, NULL);
         for (itera = 0; (itera < total_cards) && motor_state[itera]; itera++)
         {
             cntrl = (struct MMcontroller *) motor_state[itera]->DevicePrivate;
@@ -388,7 +388,7 @@ static int set_status(int card, int signal)
         if (motor_info->pid_present == YES && drvMM4000ReadbackDelay != 0)
         {
             epicsThreadSleep((double) drvMM4000ReadbackDelay/1000.0);
-            send_mess(card, READ_STATUS, (char*) NULL);
+            send_mess(card, READ_STATUS, NULL);
             recv_mess(card, cntrl->status_string, 1);
             pos = signal*5 + 3;  /* Offset in status string */
             mstat.All = cntrl->status_string[pos];
@@ -496,7 +496,7 @@ static int set_status(int card, int signal)
         nodeptr->postmsgptr != 0)
     {
         strcpy(buff, nodeptr->postmsgptr);
-        send_mess(card, buff, (char*) NULL);
+        send_mess(card, buff, NULL);
         nodeptr->postmsgptr = NULL;
     }
 
@@ -510,7 +510,7 @@ exit:
 /* send a message to the MM4000 board            */
 /* send_mess()                               */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct MMcontroller *cntrl;
     size_t size;

--- a/newportApp/src/drvPM500.cc
+++ b/newportApp/src/drvPM500.cc
@@ -99,7 +99,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PM500_num_cards = 0;
-static char *PM500_axis_names[] = {"X", "Y", "Z", "A", "B", "C", "D", "E", "F",
+static const char *PM500_axis_names[] = {"X", "Y", "Z", "A", "B", "C", "D", "E", "F",
     "G", "H", "I"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
@@ -108,7 +108,7 @@ static char *PM500_axis_names[] = {"X", "Y", "Z", "A", "B", "C", "D", "E", "F",
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -222,7 +222,8 @@ static int set_status(int card, int signal)
     struct mess_node *nodeptr;
     struct mess_info *motor_info;
     /* Message parsing variables */
-    char *axis_name, status_char, dir_char, buff[BUFF_SIZE], response[BUFF_SIZE];
+    const char *axis_name;
+    char status_char, dir_char, buff[BUFF_SIZE], response[BUFF_SIZE];
     int rtnval, rtn_state = 0;
     double motorData;
     bool ls_active;
@@ -236,7 +237,7 @@ static int set_status(int card, int signal)
 
     /* Request the status and position of this motor */
     sprintf(buff, "%sR", axis_name);
-    send_mess(card, buff, (char*) NULL);
+    send_mess(card, buff, NULL);
     rtnval = recv_mess(card, response, 1);
     if (rtnval > 0)
     {
@@ -286,7 +287,7 @@ static int set_status(int card, int signal)
 
     /* Set Motor On/Off status */
     sprintf(buff, "%sM?", axis_name);
-    send_mess(card, buff, (char*) NULL);
+    send_mess(card, buff, NULL);
     rtnval = recv_mess(card, response, 1);
     status.Bits.EA_POSITION = (int) atof(&response[2]);
 
@@ -336,7 +337,7 @@ static int set_status(int card, int signal)
     {
         strcpy(buff, nodeptr->postmsgptr);
         strcat(buff, "\r");
-        send_mess(card, buff, (char*) NULL);
+        send_mess(card, buff, NULL);
         nodeptr->postmsgptr = NULL;
     }
 
@@ -350,7 +351,7 @@ exit:
 /* send a message to the PM500 board             */
 /* send_mess()                               */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct MMcontroller *cntrl;
     size_t size;
@@ -543,7 +544,7 @@ static int motor_init()
             pasynOctetSyncIO->flush(cntrl->pasynUser);
 
             /* Send a SCUM 1 command to put device in this mode. */
-            send_mess(card_index, "SCUM 1", (char*) NULL);
+            send_mess(card_index, "SCUM 1", NULL);
             recv_mess(card_index, buff, 1);
 
             /* Set up basic controller parameters
@@ -564,21 +565,21 @@ static int motor_init()
              *   Bit 13=0, Eearly serial poll mapping
              *   Bit 14=0, No SRQ assertion
              */
-            send_mess(card_index, "SENAINT $AF", (char*) NULL);
+            send_mess(card_index, "SENAINT $AF", NULL);
             recv_mess(card_index, buff, 1);
 
             /* Send a message and read response from controller to see if
              * it exists */
-            send_mess(card_index, GET_IDENT, (char*) NULL);
+            send_mess(card_index, GET_IDENT, NULL);
             status = recv_mess(card_index, buff, 1);
             /* Return value is length of response string */
         }
 
         if (success_rtn == asynSuccess && status > 0)
         {
-            brdptr->localaddr = (char *) NULL;
+            brdptr->localaddr = NULL;
             brdptr->motor_in_motion = 0;
-            send_mess(card_index, GET_IDENT, (char*) NULL);  /* Read controller ID string */
+            send_mess(card_index, GET_IDENT, NULL);  /* Read controller ID string */
             recv_mess(card_index, buff, 1);
             strncpy(brdptr->ident, &buff[2], 50);  /* Skip "XD" */
 
@@ -588,8 +589,8 @@ static int motor_init()
             {
                 int axis_name = (int) *PM500_axis_names[total_axis];
                 brdptr->motor_info[total_axis].motor_motion = NULL;
-                sprintf(buff, "%cSTAT?", axis_name);
-                send_mess(card_index, buff, (char*) NULL);
+                sprintf(buff, "%cSTAT?", axis_name); /* TB: Should this be "%sSTAT?" instead */
+                send_mess(card_index, buff, NULL);
                 recv_mess(card_index, buff, 1);
                 if (buff[1] == 'E')
                     break;
@@ -610,11 +611,12 @@ static int motor_init()
             for (motor_index = 0; motor_index < total_axis; motor_index++)
             {
                 struct mess_info *motor_info = &brdptr->motor_info[motor_index];
-                char *firmware, *axis_name = PM500_axis_names[motor_index];
+                char *firmware;
+                const char *axis_name = PM500_axis_names[motor_index];
                 double res = 0.0;
 
                 sprintf(buff, "%sCONFIG?", axis_name);
-                send_mess(card_index, buff, (char*) NULL);
+                send_mess(card_index, buff, NULL);
                 recv_mess(card_index, buff, 1);
                 firmware = &buff[8];
                 Debug(3, "motor_init: firmware = %s\n", firmware);


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.