### PR TITLE
Update AG_CONEX.cpp

### DIFF
--- a/newportApp/src/AG_CONEX.cpp
+++ b/newportApp/src/AG_CONEX.cpp
@@ -238,6 +238,8 @@ AG_CONEXAxis::AG_CONEXAxis(AG_CONEXController *pC)
   // Compute the minimum step size
   if ((conexModel_ == ModelConexAGP) || (conexModel_ == ModelConexCC)) {
     stepSize_ = encoderIncrement_ / interpolationFactor_;
+  } else if (conexModel_ == ModelFCL200) {
++   stepSize_ = 1; // Positions in mm on this stage
   } else {
     stepSize_ = fullStepSize_ / microStepsPerFullStep_ / 1000.;
   }

--- a/newportApp/src/AG_CONEX.cpp
+++ b/newportApp/src/AG_CONEX.cpp
@@ -239,7 +239,7 @@ AG_CONEXAxis::AG_CONEXAxis(AG_CONEXController *pC)
   if ((conexModel_ == ModelConexAGP) || (conexModel_ == ModelConexCC)) {
     stepSize_ = encoderIncrement_ / interpolationFactor_;
   } else if (conexModel_ == ModelFCL200) {
-+   stepSize_ = 1; // Positions in mm on this stage
+    stepSize_ = 1; // Positions in mm on this stage
   } else {
     stepSize_ = fullStepSize_ / microStepsPerFullStep_ / 1000.;
   }


### PR DESCRIPTION
FCL200 has its own built-in controller (positioner) and you can address the positions directly in mm. The commands FRM? and FRS? are used for compatibility reasons, but lead to confusion in the driver here (wrong MRES etc.).