### PR TITLE
Set the encoder position to the same value as the motor position

### DIFF
--- a/newportApp/src/drvESP300.cc
+++ b/newportApp/src/drvESP300.cc
@@ -272,6 +272,9 @@ static int set_status(int card, int signal)
         newposition = NINT(motorData);
         status.Bits.RA_DIRECTION = (newposition >= motor_info->position) ? 1 : 0;
         motor_info->position = newposition;
+        /* Also set the encoder position, since there is only one command
+         * to query the position and the stage might have an encoder */
+        motor_info->encoder_position = newposition;
         motor_info->no_motion_count = 0;
     }
 


### PR DESCRIPTION
Set the encoder position to the same value as the motor position.  There is only one position query command and we don't know if the stage has an encoder.

This https://github.com/epics-motor/motorNewport/issues/10#issuecomment-1098044447, explains the problem and the fix.