### PR TITLE
iocs/.../Makefile may need calc

### DIFF
--- a/iocs/newportIOC/newportApp/src/Makefile
+++ b/iocs/newportIOC/newportApp/src/Makefile
@@ -23,6 +23,9 @@ newport_DBD += base.dbd
 newport_DBD += asyn.dbd
 newport_DBD += drvAsynSerialPort.dbd
 #endif
+#ifdef CALC
+newport_DBD += calc.dbd
+#endif
 newport_DBD += motorSupport.dbd
 newport_DBD += devNewport.dbd
 
@@ -31,6 +34,9 @@ newport_LIBS += Newport
 newport_LIBS += motor
 #ifdef ASYN
 newport_LIBS += asyn
+#endif
+#ifdef CALC
+newport_LIBS += calc
 #endif
 #ifdef SNCSEQ
 newport_LIBS += seq pv


### PR DESCRIPTION
Commit 9c372b32a4c6697a28841bbb93772f1454800888,
  "Added records to HXP_coords.db ..." added a db file using the sseq record.

This record is part of the calc module, which may be missing... Add it (conditionally) to iocs/newportIOC/newportApp/src/Makefile