### PR TITLE
Add Position Compare AquadB Prescaler

### DIFF
--- a/newportApp/Db/XPSPositionCompare.db
+++ b/newportApp/Db/XPSPositionCompare.db
@@ -13,6 +13,8 @@ record(mbbo,"$(P)$(R)PositionCompareMode") {
     field(TWST, "AquadB windowed")
     field(THVL, "3")
     field(THST, "AquadB always")
+    field(FRVL, "4")
+    field(FRST, "AquadB prescaler")
 }
 
 record(mbbi,"$(P)$(R)PositionCompareMode_RBV") {
@@ -26,6 +28,8 @@ record(mbbi,"$(P)$(R)PositionCompareMode_RBV") {
     field(TWST, "AquadB windowed")
     field(THVL, "3")
     field(THST, "AquadB always")
+    field(FRVL, "4")
+    field(FRST, "AquadB prescaler")
     field(SCAN, "I/O Intr")
 }
 
@@ -68,6 +72,39 @@ record(ai,"$(P)$(R)PositionCompareStepSize_RBV") {
     field(PREC,"$(PREC)")
     field(DTYP, "asynFloat64")
     field(INP,"@asyn($(PORT),$(ADDR))XPS_POSITION_COMPARE_STEP_SIZE")
+    field(SCAN, "I/O Intr")
+}
+
+record(mbbo,"$(P)$(R)PositionCompareInterFactor") {
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(ZRVL, "0")
+    field(ZRST, "4")
+    field(ONVL, "1")
+    field(ONST, "16")
+    field(TWVL, "2")
+    field(TWST, "256")
+    field(THVL, "3")
+    field(THST, "4096")
+    field(FRVL, "4")
+    field(FRST, "65536")   
+    field(OUT,"@asyn($(PORT),$(ADDR))XPS_POSITION_COMPARE_INTER_FACTOR")
+}
+
+record(mbbi,"$(P)$(R)PositionCompareInterFactor_RBV") {
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(INP,"@asyn($(PORT),$(ADDR))XPS_POSITION_COMPARE_INTER_FACTOR")
+    field(ZRVL, "0")
+    field(ZRST, "4")
+    field(ONVL, "1")
+    field(ONST, "16")
+    field(TWVL, "2")
+    field(TWST, "256")
+    field(THVL, "3")
+    field(THST, "4096")
+    field(FRVL, "4")
+    field(FRST, "65536") 
     field(SCAN, "I/O Intr")
 }
 

--- a/newportApp/src/XPSAxis.cpp
+++ b/newportApp/src/XPSAxis.cpp
@@ -940,7 +940,7 @@ double XPSAxis::XPSStepToMotorRecStep(double XPSStep)
 asynStatus XPSAxis::setPositionCompare()
 {
   int mode;
-  double minPosition, maxPosition, stepSize, pulseWidth, settlingTime;
+  double minPosition, maxPosition, interFactor, stepSize, pulseWidth, settlingTime;
   int itemp;
   int direction;
   int status;
@@ -954,6 +954,8 @@ asynStatus XPSAxis::setPositionCompare()
   pulseWidth = positionComparePulseWidths[itemp];
   pC_->getIntegerParam(axisNo_, pC_->XPSPositionCompareSettlingTime_, &itemp);
   settlingTime = positionCompareSettlingTimes[itemp];
+  pC_->getIntegerParam (axisNo_, pC_->XPSPositionCompareInterFactor_,  &itemp);
+  interFactor = positionCompareInterFactor[itemp];
   
   // minPosition and maxPosition are in motor record units. Convert to XPS units
   minPosition = motorRecPositionToXPSPosition(minPosition);
@@ -1033,8 +1035,26 @@ asynStatus XPSAxis::setPositionCompare()
         return asynError;
       }
       break;
+
+    case XPSPositionCompareModeAquadBPrescaler:
+      status = PositionerPositionCompareAquadBPrescalerSet(pollSocket_, positionerName_, interFactor);
+      if (status) {
+        asynPrint(pasynUser_, ASYN_TRACE_ERROR,
+                  "%s:%s: [%s,%d]: error calling PositionerPositionCompareAquadBPrescalerSet"
+                  " status=%d, interFactor=%f\n",
+                   driverName, functionName, pC_->portName, axisNo_, status, interFactor);
+        return asynError;
+      }
+      status = PositionerPositionCompareAquadBAlwaysEnable(pollSocket_, positionerName_);
+      if (status) {
+        asynPrint(pasynUser_, ASYN_TRACE_ERROR,
+                  "%s:%s: [%s,%d]: error calling PositionerPositionCompareAquadBAlwaysEnable status=%d\n",
+                   driverName, functionName, pC_->portName, axisNo_, status);
+        return asynError;
+      }
+      break;
   } 
-  
+   
   asynPrint(pasynUser_, ASYN_TRACE_FLOW,
             "%s:%s: set XPS %s, axis %d positionCompare set and enable\n",
              driverName, functionName, pC_->portName, axisNo_);
@@ -1048,7 +1068,7 @@ asynStatus XPSAxis::getPositionCompare()
   int status;
   int i;
   int direction;
-  double minPosition=0, maxPosition=0, stepSize=0, pulseWidth, settlingTime;
+  double minPosition=0, maxPosition=0, stepSize=0, interFactor, pulseWidth, settlingTime;
   static const char *functionName = "getPositionCompare";
   
   pC_->getIntegerParam(axisNo_, pC_->motorRecDirection_, &direction);
@@ -1057,6 +1077,13 @@ asynStatus XPSAxis::getPositionCompare()
   if (status) {
     asynPrint(pasynUser_, ASYN_TRACE_ERROR,
               "%s:%s: [%s,%d]: error calling PositionerPositionComparePulseParametersGet status=%d\n",
+               driverName, functionName, pC_->portName, axisNo_, status);
+    return asynError;
+  }
+  status = PositionerPositionCompareAquadBPrescalerGet(pollSocket_, positionerName_, &interFactor);
+  if (status) {
+    asynPrint(pasynUser_, ASYN_TRACE_ERROR,
+              "%s:%s: [%s,%d]: error calling PositionerPositionCompareAquadBPrescalerGet status=%d\n",
                driverName, functionName, pC_->portName, axisNo_, status);
     return asynError;
   }
@@ -1082,12 +1109,12 @@ asynStatus XPSAxis::getPositionCompare()
     }
 //    setDoubleParam(pC_->XPSPositionCompareMinPosition_,  XPSPositionToMotorRecPosition(minPosition));
 //    setDoubleParam(pC_->XPSPositionCompareMaxPosition_,  XPSPositionToMotorRecPosition(maxPosition));
-  } 
+  }
   asynPrint(pasynUser_, ASYN_TRACE_FLOW,
             "%s:%s: set XPS %s, axis %d "
-            " enable=%d, minPosition=%f, maxPosition=%f, stepSize=%f, pulseWidth=%f, settlingTime=%f\n",
+            " enable=%d, minPosition=%f, maxPosition=%f, stepSize=%f, interFactor=%f, pulseWidth=%f, settlingTime=%f\n",
              driverName, functionName, pC_->portName, axisNo_,
-             enable, minPosition, maxPosition, stepSize, pulseWidth, settlingTime);
+             enable, minPosition, maxPosition, stepSize, interFactor, pulseWidth, settlingTime);
 
   for (i=0; i<MAX_PULSE_WIDTHS; i++) {
     if (fabs(pulseWidth - positionComparePulseWidths[i]) < 0.001) break;
@@ -1097,6 +1124,10 @@ asynStatus XPSAxis::getPositionCompare()
     if (fabs(settlingTime - positionCompareSettlingTimes[i]) < 0.001) break;
   }
   setIntegerParam(pC_->XPSPositionCompareSettlingTime_,  i);
+  for (i=0; i<MAX_INTER_FACTOR; i++) {
+    if (fabs(interFactor - positionCompareInterFactor[i]) < 0.001) break;
+  }
+  setIntegerParam(pC_->XPSPositionCompareInterFactor_,  i);
   return asynSuccess;
 }
 

--- a/newportApp/src/XPSController.cpp
+++ b/newportApp/src/XPSController.cpp
@@ -162,6 +162,7 @@ XPSController::XPSController(const char *portName, const char *IPAddress, int IP
   createParam(XPSPositionCompareMinPositionString,    asynParamFloat64, &XPSPositionCompareMinPosition_);
   createParam(XPSPositionCompareMaxPositionString,    asynParamFloat64, &XPSPositionCompareMaxPosition_);
   createParam(XPSPositionCompareStepSizeString,       asynParamFloat64, &XPSPositionCompareStepSize_);
+  createParam(XPSPositionCompareInterFactorString,    asynParamInt32,   &XPSPositionCompareInterFactor_);
   createParam(XPSPositionComparePulseWidthString,     asynParamInt32,   &XPSPositionComparePulseWidth_);
   createParam(XPSPositionCompareSettlingTimeString,   asynParamInt32,   &XPSPositionCompareSettlingTime_);
   createParam(XPSProfileMaxVelocityString,            asynParamFloat64, &XPSProfileMaxVelocity_);
@@ -282,7 +283,7 @@ asynStatus XPSController::writeInt32(asynUser *pasynUser, epicsInt32 value)
       status = asynError;
     }
 
-  } else if ((function == XPSPositionCompareMode_) ||
+  } else if ((function == XPSPositionCompareMode_)       ||
              (function == XPSPositionComparePulseWidth_) ||
              (function == XPSPositionCompareStepSize_)) {
     status = pAxis->setPositionCompare();

--- a/newportApp/src/XPSController.h
+++ b/newportApp/src/XPSController.h
@@ -25,13 +25,16 @@ USAGE...        Newport XPS EPICS asyn motor device driver
 
 #define MAX_PULSE_WIDTHS 4
 #define MAX_SETTLING_TIMES 4
+#define MAX_INTER_FACTOR 5
 static const double positionComparePulseWidths[MAX_PULSE_WIDTHS]     = {0.2,   1.0, 2.5, 10.0};
 static const double positionCompareSettlingTimes[MAX_SETTLING_TIMES] = {0.075, 1.0, 4.0, 12.0};
+static const double positionCompareInterFactor[MAX_INTER_FACTOR] = {4, 16, 256, 4096, 65536};
 typedef enum {
   XPSPositionCompareModeDisable,
   XPSPositionCompareModePulse,
   XPSPositionCompareModeAquadBWindowed,
-  XPSPositionCompareModeAquadBAlways
+  XPSPositionCompareModeAquadBAlways,
+  XPSPositionCompareModeAquadBPrescaler
 } XPSPositionCompareMode_t;
   
 // drvInfo strings for extra parameters that the XPS controller supports
@@ -41,6 +44,7 @@ typedef enum {
 #define XPSPositionCompareMinPositionString   "XPS_POSITION_COMPARE_MIN_POSITION"
 #define XPSPositionCompareMaxPositionString   "XPS_POSITION_COMPARE_MAX_POSITION"
 #define XPSPositionCompareStepSizeString      "XPS_POSITION_COMPARE_STEP_SIZE"
+#define XPSPositionCompareInterFactorString   "XPS_POSITION_COMPARE_INTER_FACTOR"
 #define XPSPositionComparePulseWidthString    "XPS_POSITION_COMPARE_PULSE_WIDTH"
 #define XPSPositionCompareSettlingTimeString  "XPS_POSITION_COMPARE_SETTLING_TIME"
 #define XPSProfileMaxVelocityString           "XPS_PROFILE_MAX_VELOCITY"
@@ -105,6 +109,7 @@ class epicsShareClass XPSController : public asynMotorController {
   int XPSPositionCompareMinPosition_;
   int XPSPositionCompareMaxPosition_;
   int XPSPositionCompareStepSize_;
+  int XPSPositionCompareInterFactor_;
   int XPSPositionComparePulseWidth_;
   int XPSPositionCompareSettlingTime_;
   int XPSProfileMaxVelocity_;

--- a/newportApp/src/XPS_C8_drivers.cpp
+++ b/newportApp/src/XPS_C8_drivers.cpp
@@ -6193,6 +6193,83 @@ int __stdcall PositionerPositionCompareAquadBWindowedSet (int SocketIndex, char 
 
 
 /*********************************************************************** 
+ * PositionerPositionCompareAquadBPrescalerGet :  Gets PCO AquadB interpolation factor
+ *
+ *     - Parameters :
+ *            int SocketIndex
+ *            char *PositionerName
+ *            double *PCOInterpolationFactor
+ *     - Return :
+ *            int errorCode
+ ***********************************************************************/ 
+int __stdcall PositionerPositionCompareAquadBPrescalerGet (int SocketIndex, char * PositionerName, double * PCOInterpolationFactor) 
+{ 
+	int ret = -1; 
+	char ExecuteMethod[SIZE_EXECUTE_METHOD]; 
+	char *ReturnedValue = (char *) malloc (sizeof(char) * SIZE_SMALL); 
+
+	/* Convert to string */ 
+	sprintf (ExecuteMethod, "PositionerPositionCompareAquadBPrescalerGet (%s,double *)", PositionerName);
+
+	/* Send this string and wait return function from controller */ 
+	/* return function : ==0 -> OK ; < 0 -> NOK */ 
+	SendAndReceive (SocketIndex, ExecuteMethod, ReturnedValue, SIZE_SMALL); 
+	if (strlen (ReturnedValue) > 0) 
+		sscanf (ReturnedValue, "%i", &ret); 
+
+	/* Get the returned values in the out parameters */ 
+	if (ret == 0) 
+	{ 
+		char * pt;
+		char * ptNext;
+
+		pt = ReturnedValue;
+		ptNext = NULL;
+		if (pt != NULL) pt = strchr (pt, ',');
+		if (pt != NULL) pt++;
+		if (pt != NULL) sscanf (pt, "%lf", PCOInterpolationFactor);
+	} 
+	if (NULL != ReturnedValue)
+		free (ReturnedValue);
+
+	return (ret); 
+}
+
+
+/*********************************************************************** 
+ * PositionerPositionCompareAquadBPrescalerSet :  /* Sets PCO AquadB interpolation factor
+ *
+ *     - Parameters :
+ *            int SocketIndex
+ *            char *PositionerName
+ *            double PCOInterpolationFactor
+ *     - Return :
+ *            int errorCode
+ ***********************************************************************/ 
+int __stdcall PositionerPositionCompareAquadBPrescalerSet (int SocketIndex, char * PositionerName, double PCOInterpolationFactor)
+{ 
+	int ret = -1; 
+	char ExecuteMethod[SIZE_EXECUTE_METHOD]; 
+	char *ReturnedValue = (char *) malloc (sizeof(char) * SIZE_SMALL); 
+
+	/* Convert to string */ 
+	sprintf (ExecuteMethod, "PositionerPositionCompareAquadBPrescalerSet (%s,%.13g)", PositionerName, PCOInterpolationFactor);
+
+	/* Send this string and wait return function from controller */ 
+	/* return function : ==0 -> OK ; < 0 -> NOK */ 
+	SendAndReceive (SocketIndex, ExecuteMethod, ReturnedValue, SIZE_SMALL); 
+	if (strlen (ReturnedValue) > 0) 
+		sscanf (ReturnedValue, "%i", &ret); 
+
+	/* Get the returned values in the out parameters */ 
+	if (NULL != ReturnedValue)
+		free (ReturnedValue);
+
+	return (ret); 
+}
+
+
+/*********************************************************************** 
  * PositionerPositionCompareGet :  Read position compare parameters
  *
  *     - Parameters :

--- a/newportApp/src/XPS_C8_drivers.h
+++ b/newportApp/src/XPS_C8_drivers.h
@@ -160,6 +160,8 @@ DLL int __stdcall PositionerMotionDoneSet (int SocketIndex, char * PositionerNam
 DLL int __stdcall PositionerPositionCompareAquadBAlwaysEnable (int SocketIndex, char * PositionerName);  /* Enable AquadB signal in always mode */
 DLL int __stdcall PositionerPositionCompareAquadBWindowedGet (int SocketIndex, char * PositionerName, double * MinimumPosition, double * MaximumPosition, bool * EnableState);  /* Read position compare AquadB windowed parameters */
 DLL int __stdcall PositionerPositionCompareAquadBWindowedSet (int SocketIndex, char * PositionerName, double MinimumPosition, double MaximumPosition);  /* Set position compare AquadB windowed parameters */
+DLL int __stdcall PositionerPositionCompareAquadBPrescalerGet (int SocketIndex, char * PositionerName, double * PCOInterpolationFactor); /* Gets PCO AquadB interpolation factor */
+DLL int __stdcall PositionerPositionCompareAquadBPrescalerSet (int SocketIndex, char * PositionerName, double PCOInterpolationFactor);  /* Sets PCO AquadB interpolation factor */
 DLL int __stdcall PositionerPositionCompareGet (int SocketIndex, char * PositionerName, double * MinimumPosition, double * MaximumPosition, double * PositionStep, bool * EnableState);  /* Read position compare parameters */
 DLL int __stdcall PositionerPositionCompareSet (int SocketIndex, char * PositionerName, double MinimumPosition, double MaximumPosition, double PositionStep);  /* Set position compare parameters */
 DLL int __stdcall PositionerPositionCompareEnable (int SocketIndex, char * PositionerName);  /* Enable position compare */


### PR DESCRIPTION
Hello everyone,

At Sirius, we use several units of the Newport XPS controller. However, before enabling AquadB Always for our experiments, it is necessary to configure the AquadB Prescaler interpolation factor.

To avoid impacting the current operation of this module, I chose to add a new mode that configures the AquadB Prescaler and enables AquadB Always at the same time.

Thanks.